### PR TITLE
Height should take into account padding-top and padding-bottom

### DIFF
--- a/inobounce.js
+++ b/inobounce.js
@@ -24,7 +24,9 @@
 
 			var scrolling = style.getPropertyValue('-webkit-overflow-scrolling');
 			var overflowY = style.getPropertyValue('overflow-y');
-			var height = parseInt(style.getPropertyValue('height'), 10);
+			var paddingTop = parseInt(style.getPropertyValue('padding-top'), 10);
+			var paddingBot = parseInt(style.getPropertyValue('padding-bottom'), 10);
+			var height = paddingTop+paddingBot+parseInt(style.getPropertyValue('height'), 10);
 
 			// Determine if the element should scroll
 			var isScrollable = scrolling === 'touch' && (overflowY === 'auto' || overflowY === 'scroll');


### PR DESCRIPTION
When detecting if element is at bottom, the height should take into account padding-top and padding-bottom, otherwise it won't work, and the page will "bounce" when you drag elements with padding (when they are at the bottom scroll position)