### PR TITLE
height should be round

### DIFF
--- a/inobounce.js
+++ b/inobounce.js
@@ -42,7 +42,7 @@
 				// Determine if the user is trying to scroll past the top or bottom
 				// In this case, the window will bounce, so we have to prevent scrolling completely
 				var isAtTop = (startY <= curY && el.scrollTop === 0);
-				var isAtBottom = (startY >= curY && el.scrollHeight - el.scrollTop === height);
+				var isAtBottom = (startY >= curY && el.scrollHeight - el.scrollTop == height);
 
 				// Stop a bounce bug when at the bottom or top of the scrollable element
 				if (isAtTop || isAtBottom) {

--- a/inobounce.js
+++ b/inobounce.js
@@ -29,7 +29,7 @@
 
 			var scrolling = style.getPropertyValue('-webkit-overflow-scrolling');
 			var overflowY = style.getPropertyValue('overflow-y');
-			var height = parseInt(style.getPropertyValue('height'), 10);
+			var height = parseFloat(style.getPropertyValue('height'), 10).toFixed(0);
 
 			// Determine if the element should scroll
 			var isScrollable = scrolling === 'touch' && (overflowY === 'auto' || overflowY === 'scroll');


### PR DESCRIPTION
I ran into a bug on the iPhone 7 Plus. `el.scrollHeight - el.scrollTop` get 562. But the height is 561. So it does not satisfy the condition of `el.scrollHeight - el.scrollTop === height`