### PR TITLE
Fixing issue where scrolling locks in iOS13:

### DIFF
--- a/inobounce.js
+++ b/inobounce.js
@@ -43,12 +43,11 @@
 				return;
 			}
 
-			var scrolling = style.getPropertyValue('-webkit-overflow-scrolling');
 			var overflowY = style.getPropertyValue('overflow-y');
 			var height = parseInt(style.getPropertyValue('height'), 10);
 
 			// Determine if the element should scroll
-			var isScrollable = scrolling === 'touch' || overflowY === 'auto' || overflowY === 'scroll';
+			var isScrollable = overflowY === 'auto' || overflowY === 'scroll';
 			var canScroll = el.scrollHeight > el.offsetHeight;
 
 			if (isScrollable && canScroll) {

--- a/inobounce.js
+++ b/inobounce.js
@@ -48,7 +48,7 @@
 			var height = parseInt(style.getPropertyValue('height'), 10);
 
 			// Determine if the element should scroll
-			var isScrollable = scrolling === 'touch' && (overflowY === 'auto' || overflowY === 'scroll');
+			var isScrollable = scrolling === 'touch' || overflowY === 'auto' || overflowY === 'scroll';
 			var canScroll = el.scrollHeight > el.offsetHeight;
 
 			if (isScrollable && canScroll) {


### PR DESCRIPTION
`-webkit-overflow-scrolling` is now disabled, see https://developer.apple.com/documentation/safari_release_notes/safari_13_release_notes

This patch considers backwards compatibility as well as future-facing updates